### PR TITLE
to_filesize should be public

### DIFF
--- a/libraries/disk_usage.rb
+++ b/libraries/disk_usage.rb
@@ -21,15 +21,14 @@ class DiskUsage < Inspec.resource(1)
     end
   end
 
-  private
-
   # need to normalize the filesize
   def to_filesize(size)
     # size = '0' if size.nil?
+    size = size.to_s
 
     units = {
-      'B' => 1 / (1024 * 1024),
-      'K' => 1 / 1024,
+      'B' => 1.0 / (1024 * 1024),
+      'K' => 1.0 / 1024,
       'M' => 1,
       'G' => 1024,
       'T' => 1024 * 1024
@@ -40,6 +39,8 @@ class DiskUsage < Inspec.resource(1)
 
     "#{size[0..-1].to_f * units[unit]}M"
   end
+
+  private
 
   def parse_mounts(input)
     diskusage = []

--- a/spec/disk_usage_spec.rb
+++ b/spec/disk_usage_spec.rb
@@ -26,6 +26,11 @@ describe_inspec_resource 'disk_usage' do
     let(:rootfs) { resource.mount('/') }
     let(:nofs) { resource.mount('nofs') }
 
+    it 'should return a standardize size' do
+      expect(resource.to_filesize('250M')).to eq '250.0M'
+      expect(resource.to_filesize(262144000)).to eq '250.0M'
+    end
+
     it 'should find root fs' do
       expect(rootfs.exists?).to eq true
     end


### PR DESCRIPTION
This is used by some inspec controls to test against a standardized
format for the FS size

Signed-off-by: Will Fisher <wfisher@chef.io>